### PR TITLE
Add workflow to check for do-not-merge label

### DIFF
--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -11,17 +11,8 @@ jobs:
     steps:
       - name: Check for "do-not-merge" Label
         id: check_label
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # https://stackoverflow.com/a/71510189/992102
+        if: contains(github.event.pull_request.labels.*.name, 'do-not-merge')
         run: |
-          labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
-
-          if [[ $? -ne 0 ]]; then
-            echo "Failed to retrieve PR labels."
-            exit 1
-          fi
-
-          if echo "$labels" | grep -qw do-not-merge; then
-            echo "DO NOT MERGE"
-            exit 1
-          fi
+          echo "Failed to retrieve PR labels."
+          exit 1

--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -1,0 +1,25 @@
+name: Check for "do-not-merge" label
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, synchronize, opened]
+
+jobs:
+  check_do_not_merge_label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check for "do-not-merge" Label
+        id: check_label
+        run: |
+          labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
+
+          if [[ $? -ne 0 ]]; then
+            echo "Failed to retrieve PR labels."
+            exit 1
+          fi
+
+          if echo "$labels" | grep -qw do-not-merge; then
+            echo "DO NOT MERGE"
+            exit 1
+          fi

--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Check for "do-not-merge" Label
         id: check_label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels --jq '.labels[].name')
 


### PR DESCRIPTION
This PR adds a github workflow to check for a `do-not-merge` label. PRs with this label cannot be merged. Used to prevent merging of the Crowdin PR.