### PR TITLE
Add terms.md to ignore list on Crowdin

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -6,6 +6,8 @@ files:
   - source: /content/en/*.md
     translation: /content/%two_letters_code%/%original_file_name%
     update_option: update_as_unapproved
+    ignore:
+      - /content/en/terms.md
   - source: /content/en/teams/*.md
     translation: /content/%two_letters_code%/%original_file_name%
     update_option: update_as_unapproved


### PR DESCRIPTION
This PR adds `content/en/terms.md` to the ignore list. This is a legal document, and my understanding is that any translation would need to go through a lawyer to verify that the legal meaning is preserved. It's safer not to translate things like this and it was an oversight to not have it added to Crowdin's ignore list.