### PR TITLE
Update translations for Japanese

### DIFF
--- a/content/ja/teams/index.md
+++ b/content/ja/teams/index.md
@@ -9,9 +9,9 @@ GitHubでマージ権をもつ開発者
 
 {{< grid file="maintainers.toml" columns="2 3 4 5" />}}
 
-### Typing team
+### 型ヒントチーム
 
-Contributors with merge rights on `scipy-stubs`.
+`scipy-stubs` のマージ権限を持つコントリビュータ
 
 {{< grid file="typing-team.toml" columns="2 3 4 5" />}}
 

--- a/content/ja/teams/index.md
+++ b/content/ja/teams/index.md
@@ -9,6 +9,12 @@ GitHubでマージ権をもつ開発者
 
 {{< grid file="maintainers.toml" columns="2 3 4 5" />}}
 
+### Typing team
+
+Contributors with merge rights on `scipy-stubs`.
+
+{{< grid file="typing-team.toml" columns="2 3 4 5" />}}
+
 ### トリアージチーム
 
 GitHubでトリアージ権をもつ開発者

--- a/content/ja/teams/typing-team.toml
+++ b/content/ja/teams/typing-team.toml
@@ -1,0 +1,19 @@
+[[item]]
+type = 'card'
+classcard = 'text-center'
+body = '''{{< image >}}
+src = 'https://avatars.githubusercontent.com/u/6208662?u=f5b6702cd80c1cd85d9a9cdc84fee65bedae24ca&v=4"'
+alt = 'Avatar of Joren Hammudoglu'
+{{< /image >}}
+Joren Hammudoglu'''
+link = 'https://github.com/jorenham'
+
+[[item]]
+type = 'card'
+classcard = 'text-center'
+body = '''{{< image >}}
+src = 'https://avatars.githubusercontent.com/u/98330?u=22a023f8d191ba200ab13d476c83860d015cc9fe&v=4"'
+alt = 'Avatar of Ralf Gommers'
+{{< /image >}}
+Ralf Gommers'''
+link = 'https://github.com/rgommers'


### PR DESCRIPTION
This PR to update translations for Japanese was generated by the GitHub workflow, `.github/workflows/sync_translations.yml` and includes all commits from this repo's Crowdin branch for the language of interest.