### PR TITLE
Update translations for Portuguese, Brazilian

### DIFF
--- a/content/pt/teams/index.md
+++ b/content/pt/teams/index.md
@@ -9,6 +9,12 @@ Contributors with merge rights on GitHub.
 
 {{< grid file="maintainers.toml" columns="2 3 4 5" />}}
 
+### Typing team
+
+Contributors with merge rights on `scipy-stubs`.
+
+{{< grid file="typing-team.toml" columns="2 3 4 5" />}}
+
 ### Equipe de Triagem
 
 Contributors with triage rights on GitHub.

--- a/content/pt/teams/typing-team.toml
+++ b/content/pt/teams/typing-team.toml
@@ -1,0 +1,19 @@
+[[item]]
+type = 'card'
+classcard = 'text-center'
+body = '''{{< image >}}
+src = 'https://avatars.githubusercontent.com/u/6208662?u=f5b6702cd80c1cd85d9a9cdc84fee65bedae24ca&v=4"'
+alt = 'Avatar of Joren Hammudoglu'
+{{< /image >}}
+Joren Hammudoglu'''
+link = 'https://github.com/jorenham'
+
+[[item]]
+type = 'card'
+classcard = 'text-center'
+body = '''{{< image >}}
+src = 'https://avatars.githubusercontent.com/u/98330?u=22a023f8d191ba200ab13d476c83860d015cc9fe&v=4"'
+alt = 'Avatar of Ralf Gommers'
+{{< /image >}}
+Ralf Gommers'''
+link = 'https://github.com/rgommers'


### PR DESCRIPTION
This PR to update translations for Portuguese, Brazilian was generated by the GitHub workflow, `.github/workflows/sync_translations.yml` and includes all commits from this repo's Crowdin branch for the language of interest.